### PR TITLE
Replace `panic!()` with `Option<i128>` in `fixed_div_floor`, prevent overflows

### DIFF
--- a/oracle/src/prices.rs
+++ b/oracle/src/prices.rs
@@ -336,7 +336,11 @@ pub fn fixed_div_floor(dividend: i128, divisor: i128, decimals: u32) -> Option<i
     let mut vdividend = dividend;
     let mut vdivisor = divisor;
     if ashift > 0 {
-        vdividend *= 10_i128.pow(ashift);
+        let svdividend = vdividend.checked_mul(10_i128.pow(ashift));
+        if svdividend.is_none() {
+            return None;
+        }
+        vdividend = svdividend?;
     }
     if bshift > 0 {
         vdivisor /= 10_i128.pow(bshift);

--- a/oracle/src/tests/util_tests.rs
+++ b/oracle/src/tests/util_tests.rs
@@ -26,6 +26,7 @@ fn generate_update_record_mask(e: &Env, updates: &Vec<i128>) -> Bytes {
 #[test_case(0, -1i128, 14)]
 #[test_case(-1, -1, 14)]
 #[test_case(1000000000000000000000, 5, 18)]
+#[test_case(5000000000000000000000000000000, 10000000000, 14)]
 #[test_case(i128::MAX, 1, 14)]
 fn fixed_div_floor_failed_tests(a: i128, b: i128, decimals: u32) {
     let result = prices::fixed_div_floor(a.clone(), b, decimals);


### PR DESCRIPTION
Ref S-34, S-96, S-431