### PR TITLE
Replace hardcoded period `1` with `records` argument in `twap()`

### DIFF
--- a/beam-contract/src/lib.rs
+++ b/beam-contract/src/lib.rs
@@ -292,7 +292,7 @@ impl BeamOracleContract {
     // TWAP for the given asset over N recent records or None if asset is not supported
     pub fn twap(e: &Env, caller: Address, asset: Asset, records: u32) -> Option<i128> {
         caller.require_auth();
-        charge_invocation_fee(e, &caller, InvocationComplexity::Twap, 1);
+        charge_invocation_fee(e, &caller, InvocationComplexity::Twap, records);
         PriceOracleContractBase::twap(e, asset, records)
     }
 


### PR DESCRIPTION
Ref S-832