### PR TITLE
Fix units mismatch comments, update `expires()` to return seconds

### DIFF
--- a/beam-contract/src/lib.rs
+++ b/beam-contract/src/lib.rs
@@ -93,7 +93,7 @@ impl BeamOracleContract {
     //
     // # Returns
     //
-    // Asset expiration timestamp or None if asset is not supported
+    // Asset expiration timestamp (in seconds) or None if asset is not supported
     //
     // # Panics
     //
@@ -368,7 +368,7 @@ impl BeamOracleContract {
     //
     // # Arguments
     //
-    // * `period` - History retention period (in seconds)
+    // * `period` - History retention period (in milliseconds)
     //
     // # Panics
     //

--- a/oracle/src/assets.rs
+++ b/oracle/src/assets.rs
@@ -79,7 +79,7 @@ pub fn add_assets(e: &Env, assets: Vec<Asset>, initial_expiration_period: u32) {
     set_expirations_records(e, &expiration);
 }
 
-// Retrieve expiration time for given asset
+// Retrieve expiration timestamp for given asset
 pub fn expires(e: &Env, asset: Asset) -> Option<u64> {
     let asset_index = resolve_asset_index(e, &asset);
     if asset_index.is_none() {

--- a/oracle/src/price_oracle.rs
+++ b/oracle/src/price_oracle.rs
@@ -96,13 +96,16 @@ impl PriceOracleContractBase {
     //
     // # Returns
     //
-    // Asset expiration timestamp or None if asset is not supported
+    // Asset expiration timestamp (in seconds) or None if asset is not supported
     //
     // # Panics
     //
     // Panics if asset is not supported
     pub fn expires(e: &Env, asset: Asset) -> Option<u64> {
-        assets::expires(e, asset)
+        match assets::expires(e, asset) {
+            Some(ts) => Some(ts / 1000), //convert to seconds
+            None => None,
+        }
     }
 
     // Extends the asset expiration date by a given amount of tokens.
@@ -325,8 +328,8 @@ impl PriceOracleContractBase {
     // * `admin` - Admin address
     // * `base` - Base asset
     // * `decimals` - Number of decimals for price records
-    // * `resolution` - History timeframe resolution (in seconds)
-    // * `history_retention_period` - Price history retention period (in seconds)
+    // * `resolution` - History timeframe resolution (in milliseconds)
+    // * `history_retention_period` - Price history retention period (in milliseconds)
     // * `cache_size` - Number of rounds held in instance cache
     // * `fee_config` - Contract retention config
     // * `assets` - Initial list of supported assets
@@ -390,7 +393,7 @@ impl PriceOracleContractBase {
     //
     // # Arguments
     //
-    // * `period` - History retention period (in seconds)
+    // * `period` - History retention period (in milliseconds)
     //
     // # Panics
     //

--- a/oracle/src/types.rs
+++ b/oracle/src/types.rs
@@ -14,7 +14,7 @@ pub enum Asset {
 pub struct ConfigData {
     // Admin address
     pub admin: Address,
-    // Price history retention period
+    // Price history retention period (in milliseconds)
     pub history_retention_period: u64,
     // List of supported assets
     pub assets: Vec<Asset>,
@@ -22,7 +22,7 @@ pub struct ConfigData {
     pub base_asset: Asset,
     // Number of decimals for price records
     pub decimals: u32,
-    // History timeframe resolution
+    // History timeframe resolution (in milliseconds)
     pub resolution: u32,
     // Number of rounds held in instance cache
     pub cache_size: u32,

--- a/pulse-contract/src/lib.rs
+++ b/pulse-contract/src/lib.rs
@@ -311,7 +311,7 @@ impl PulseOracleContract {
     //
     // # Arguments
     //
-    // * `period` - History retention period (in seconds)
+    // * `period` - History retention period (in milliseconds)
     //
     // # Panics
     //
@@ -340,7 +340,7 @@ impl PulseOracleContract {
     // # Arguments
     //
     // * `updates` - Price feed snapshot
-    // * `timestamp` - History snapshot timestamp
+    // * `timestamp` - History snapshot timestamp (in milliseconds)
     //
     // # Panics
     //

--- a/pulse-contract/src/tests/contract_admin_tests.rs
+++ b/pulse-contract/src/tests/contract_admin_tests.rs
@@ -233,10 +233,13 @@ fn set_fee_config_test() {
     fee_token.mint(&sponsor, &10);
 
     let symbol_expires = client.expires(&asset).unwrap();
-    assert_eq!(symbol_expires, 15552900000); // 900s current ledger timestamp + 180 days of initial expiration period
+    assert_eq!(symbol_expires, 15552900); // 900s current ledger timestamp + 180 days of initial expiration period
     client.extend_asset_ttl(&sponsor, &asset, &10);
     //123428571 ms you get for 10 XRF tokens
-    assert_eq!(client.expires(&asset).unwrap(), symbol_expires + 123428571);
+    assert_eq!(
+        client.expires(&asset).unwrap(),
+        symbol_expires + 123428571 / 1000
+    );
 
     let fee_token_balance = TokenClient::new(&env, &fee_asset.address()).balance(&sponsor);
     assert_eq!(fee_token_balance, 0);

--- a/pulse-contract/src/tests/contract_interface_tests.rs
+++ b/pulse-contract/src/tests/contract_interface_tests.rs
@@ -6,8 +6,9 @@ use crate::tests::setup_tests::{
 };
 use oracle::prices;
 use oracle::types::FeeConfig;
-use soroban_sdk::testutils::{Ledger, LedgerInfo};
-use soroban_sdk::Vec;
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Vec};
 
 #[test]
 fn version_test() {
@@ -129,4 +130,33 @@ fn prices_test() {
     }
     assert!(had_prices);
     assert!(had_gaps);
+}
+
+#[test]
+fn extend_asset_ttl_test() {
+    let (env, client, init_data) = init_contract();
+
+    env.mock_all_auths();
+
+    let fee_asset = env
+        .register_stellar_asset_contract_v2(init_data.admin.clone())
+        .address();
+    let fee_config = FeeConfig::Some((fee_asset.clone(), 1_000_000));
+    client.set_fee_config(&fee_config);
+
+    //generate sponsor and mint fee tokens
+    let sponsor = Address::generate(&env);
+    let token_client = StellarAssetClient::new(&env, &fee_asset);
+    token_client.mint(&sponsor, &10_000_000);
+
+    //get initial expiration
+    let asset = &init_data.assets.first_unchecked();
+    let initial_expiration = client.expires(&asset).unwrap();
+
+    //extend TTL by 10 day (864000 seconds)
+    client.extend_asset_ttl(&sponsor, &asset, &10_000_000);
+
+    //verify new expiration
+    let new_expiration = client.expires(&asset).unwrap();
+    assert_eq!(new_expiration, initial_expiration + 864000);
 }


### PR DESCRIPTION
Fix units mismatch in comments. Return seconds from expires function
Ref S-790